### PR TITLE
fix(deps): glob not specified as dependency broke usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,12 @@
   },
   "devDependencies": {
     "@spotify/web-scripts": "^1.1.4",
+    "@types/glob": "^7.1.1",
     "@types/mock-fs": "^3.6.30",
     "husky": "^3.0.0",
     "mock-fs": "^4.10.1"
+  },
+  "dependencies": {
+    "glob": "^7.1.4"
   }
 }


### PR DESCRIPTION
web-scripts uses glob, so glob was flattened in the tree allowing all the tests to pass. But an
install/use would fail!

BREAKING CHANGE: package was broken before